### PR TITLE
Allows logging of debug data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Usage:
 The built-in `Whitelist` supports plugins using `entry_points` with a key of `"logging.extra.whitelist"`. Each
 registered entry point must be a callable that returns an iterable of string.
 
+In some cases you may want to log sensitive data only in debugging senarios.  This is supported in 2 ways:
+1. We do not check the logging.extra.whitelist for lines logged at the `debug` level
+2. You may also prefix a keyword with 'debug\_' and log it at another level.  You can safely assume these will be
+   filtered out of shipped logs.
 
 ## Violations Detected
 

--- a/logging_format/tests/test_visitor.py
+++ b/logging_format/tests/test_visitor.py
@@ -139,9 +139,9 @@ def test_debug_ok_with_not_whitelisted_keyword():
         import logging
 
         logging.debug(
-            "Hello {hello}!",
+            "Hello {goodbye}!",
             extra=dict(
-              hello="{}",
+              goodbye="{}",
             ),
         )
         logging.info(

--- a/logging_format/tests/test_visitor.py
+++ b/logging_format/tests/test_visitor.py
@@ -106,7 +106,7 @@ def test_extra_with_whitelisted_keyword():
     assert_that(visitor.violations, is_(empty()))
 
 
-def test_extra_with_nont_whitelisted_keyword():
+def test_extra_with_not_whitelisted_keyword():
     """
     Extra keyword is not ok if not in whitelist.
 
@@ -128,6 +128,59 @@ def test_extra_with_nont_whitelisted_keyword():
     assert_that(whitelist, contains("world"))
     assert_that(visitor.violations, has_length(1))
     assert_that(visitor.violations[0][1], is_(equal_to(WHITELIST_VIOLATION.format("hello"))))
+
+
+def test_debug_ok_with_not_whitelisted_keyword():
+    """
+    Extra keyword is ok for debug if not in whitelist.
+
+    """
+    tree = parse(dedent("""\
+        import logging
+
+        logging.debug(
+            "Hello {hello}!",
+            extra=dict(
+              hello="{}",
+            ),
+        )
+        logging.info(
+            "Hello {hello}!",
+            extra=dict(
+              hello="{}",
+            ),
+        )
+    """))
+    whitelist = Whitelist(group="logging.extra.example")
+    visitor = LoggingVisitor(whitelist=whitelist)
+    visitor.visit(tree)
+
+    assert_that(whitelist, contains("world"))
+    assert_that(visitor.violations, has_length(1))
+    assert_that(visitor.violations[0][1], is_(equal_to(WHITELIST_VIOLATION.format("hello"))))
+
+
+def test_debug_prefix_ok_with_not_whitelisted_keyword():
+    """
+    Extra keyword is ok if prefix 'debug_'.
+
+    """
+    tree = parse(dedent("""\
+        import logging
+
+        logging.info(
+            "Hello {debug_hello}!",
+            extra=dict(
+              debug_hello="{}",
+            ),
+        )
+    """))
+    whitelist = Whitelist(group="logging.extra.example")
+    visitor = LoggingVisitor(whitelist=whitelist)
+    visitor.visit(tree)
+
+    assert_that(whitelist, contains("world"))
+    assert_that(visitor.violations, is_(empty()))
 
 
 def test_extra_with_non_whitelisted_dict_keyword():


### PR DESCRIPTION
- Skips checking lines logged at debug level
- Skips ckecking keywords prefixed with 'debug_'