### PR TITLE
Check f-string (in Python 3.6+)

### DIFF
--- a/logging_format/tests/test_visitor.py
+++ b/logging_format/tests/test_visitor.py
@@ -3,6 +3,7 @@ Visitor tests.
 
 """
 from ast import parse
+from sys import version_info
 from textwrap import dedent
 
 from hamcrest import (
@@ -18,6 +19,7 @@ from logging_format.violations import (
     PERCENT_FORMAT_VIOLATION,
     STRING_CONCAT_VIOLATION,
     STRING_FORMAT_VIOLATION,
+    FSTRING_VIOLATION,
     WARN_VIOLATION,
     WHITELIST_VIOLATION,
 )
@@ -256,6 +258,24 @@ def test_format_percent():
 
     assert_that(visitor.violations, has_length(1))
     assert_that(visitor.violations[0][1], is_(equal_to(PERCENT_FORMAT_VIOLATION)))
+
+
+def test_fstring():
+    """
+    F-Strings are not ok in logging statements.
+
+    """
+    if version_info >= (3, 6):
+        tree = parse(dedent("""\
+            import logging
+            name = "world"
+            logging.info(f"Hello {name}")
+        """))
+        visitor = LoggingVisitor()
+        visitor.visit(tree)
+
+        assert_that(visitor.violations, has_length(1))
+        assert_that(visitor.violations[0][1], is_(equal_to(FSTRING_VIOLATION)))
 
 
 def test_string_concat():

--- a/logging_format/violations.py
+++ b/logging_format/violations.py
@@ -9,6 +9,8 @@ STRING_CONCAT_VIOLATION = "G003 Logging statement uses '+'"
 
 PERCENT_FORMAT_VIOLATION = "G002 Logging statement uses '%'"
 
+FSTRING_VIOLATION = "G004 Logging statement uses f-string"
+
 WARN_VIOLATION = "G010 Logging statement uses 'warn' instead of 'warning'"
 
 WHITELIST_VIOLATION = "G100 Logging statement uses non-whitelisted extra keyword argument: {}"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, lint
+envlist = py27, py35, py36, lint
 
 [testenv]
 commands =


### PR DESCRIPTION
Hi :)

This checks for f-strings in Python 3.6 or later.

I think that this checking for the Python version (`if version_info >= (3, 6)`) is not super elegant, so If you have a nicer way to do it please tell me. :)

🙂