### PR TITLE
Also check calls to logging.exception()

### DIFF
--- a/logging_format/visitor.py
+++ b/logging_format/visitor.py
@@ -29,6 +29,7 @@ LOGGING_LEVELS = {
     "debug",
     "critical",
     "error",
+    "exception",
     "info",
     "warn",
     "warning",


### PR DESCRIPTION
This is kind of backwards incompatible in that people will see errors that didn't see before, but I think it's still sensible to treat `logging.exception()` the same as the rest.