### PR TITLE
Check for usage of exceptions in logging arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ In some cases you may want to log sensitive data only in debugging senarios.  Th
  -  `G004` Logging statements should not use `f"..."` for their first argument (only in Python 3.6+)
  -  `G010` Logging statements should not use `warn` (use `warning` instead)
  -  `G100` Logging statements should not use `extra` arguments unless whitelisted
+ -  `G200` Logging statements should not include the exception in logged string (use `exception` or `exc_info=True`)
+ -  `G201` Logging statements should not use `error(..., exc_info=True)` (use `exception(...)` instead)
+ -  `G202` Logging statements should not use redundant `exc_info=True` in `exception` 
 
 These violations are disabled by default. To enable them for your project, specify the code(s) in your `setup.cfg`:
 

--- a/logging_format/violations.py
+++ b/logging_format/violations.py
@@ -14,3 +14,8 @@ FSTRING_VIOLATION = "G004 Logging statement uses f-string"
 WARN_VIOLATION = "G010 Logging statement uses 'warn' instead of 'warning'"
 
 WHITELIST_VIOLATION = "G100 Logging statement uses non-whitelisted extra keyword argument: {}"
+
+EXCEPTION_VIOLATION = "G200 Logging statement uses exception in arguments"
+
+ERROR_EXC_INFO_VIOLATION = "G201 Logging: .exception(...) should be used instead of .error(..., exc_info=True)"
+REDUNDANT_EXC_INFO_VIOLATION = "G202 Logging statement has redundant exc_info"


### PR DESCRIPTION
I've added some new violations to check:
* Check that logging calls in `except` blocks do not incorporate exceptions into the message (`logger.exception` or is preferred, or `exc_info=True` for level other than ERROR)
* Check for `logger.error(..., exc_info=True)` (`logging.exception` is preferred)
* Check for redundant `logger.exception(..., exc_info=True)`