### PR TITLE
Add README to pypi page

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,8 @@
+[metadata]
+description = Flake8 extension to validate (lack of) logging format strings
+long_description = file: README.md
+long_description_content_type = text/markdown
+
 [nosetests]
 with-coverage = 0
 cover-package = logging_format

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ version = "0.6.0"
 setup(
     name=project,
     version=version,
-    description="Flake8 extension to validate (lack of) logging format strings",
     author="Globality Engineering",
     author_email="engineering@globality.com",
     url="https://github.com/globality-corp/flake8-logging-format",


### PR DESCRIPTION
Currently, it looks like this: https://pypi.org/project/flake8-logging-format/

The change would use the currend README.md to be displayed there. A new update of the plugin on pypi is necessary for this to be active.

Example where you can see this:

* PyPI: https://pypi.org/project/mpu/
* Github: https://github.com/MartinThoma/mpu