### PR TITLE
Switch testing from nose to pytest

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,8 +22,8 @@
 if [ "$1" = "test" ]; then
     # Install standard test dependencies; YMMV
     pip --quiet install \
-        .[test] nose mock PyHamcrest coverage
-    exec nosetests ${NAME}
+        .[test] pytest mock PyHamcrest coverage
+    exec pytest ${NAME}
 elif [ "$1" = "lint" ]; then
     # Install standard linting dependencies; YMMV
     pip --quiet install \

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,10 +3,6 @@ description = Flake8 extension to validate (lack of) logging format strings
 long_description = file: README.md
 long_description_content_type = text/markdown
 
-[nosetests]
-with-coverage = 0
-cover-package = logging_format
-
 [flake8]
 max-line-length = 120
 max-complexity = 15

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
     install_requires=[
     ],
     setup_requires=[
-        "nose>=1.3.7",
     ],
     dependency_links=[
     ],
@@ -29,10 +28,6 @@ setup(
             "example = logging_format.whitelist:example_whitelist",
         ],
     },
-    tests_require=[
-        "coverage>=3.5.2",
-        "PyHamcrest>=1.9.0",
-    ],
     classifiers=[
         "Framework :: Flake8",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,13 @@ envlist = py27, py35, py36, lint
 
 [testenv]
 commands =
-    python setup.py nosetests --with-coverage --cover-package=logging_format --cover-erase --cover-html
+    pytest --cov=logging_format --cov-report html --cov-report term ./logging_format/tests/
     python setup.py sdist
 deps =
+    pytest
+    pytest-cov
+    coverage>=3.5.2
+    PyHamcrest>=1.9.0
     setuptools>=17.1
 
 [testenv:lint]
@@ -14,3 +18,6 @@ basepython=python2.7
 deps=
     flake8
     flake8-print
+
+[coverage:run]
+omit = logging_format/tests/*, logging_format/api.py


### PR DESCRIPTION
Maintenance on the nose test framework stopped about 6 years ago,
with devs advising users to find another framework[1]

pytest on the other hand has a thriving community, and seems
like a nice modern alternative to nose.

Note that tests are no longer going to be run from 'setup.py test'
per current pythonic best practices[2], but rather from tox

  tox -e py36 testenv

Also note the coverage exclude rule in tox.ini includes an exclusion for api.py
since that was excluded from the old nosetests report.

[1] https://nose.readthedocs.io/en/latest/#note-to-users
[2] https://docs.pytest.org/en/latest/explanation/goodpractices.html#do-not-run-via-setuptools