### PR TITLE
Use correct error code format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     ],
     entry_points={
         "flake8.extension": [
-            "logging-format = logging_format.api:LoggingFormatValidator",
+            "G = logging_format.api:LoggingFormatValidator",
         ],
         "logging.extra.example": [
             "example = logging_format.whitelist:example_whitelist",


### PR DESCRIPTION
*flake8* has always expected codes to use formats like `E123` or `W451`. More complex codes like `COMPANY-UNIT-TESTS-FILEPATH` have traditionally worked everywhere *except* in flake8 configuration files, and attempts to change this have been rejected [1]. The upcoming version of flake8 now enforced this practice everywhere, which is resulting in the following error message when attempting to use *flake8-logging-format* with master of *flake8* [2]:

    There was a critical error during execution of Flake8:
    plugin code for `flake8-logging-format[logging-format]` does not match
    ^[A-Z]{1,3}[0-9]{0,3}$

The resolution here is change our code to something that matches this pattern. We use `G` as this matches the codes provided by this plugin.

[1] https://github.com/PyCQA/flake8/issues/1568
[2] https://github.com/PyCQA/flake8/issues/325
