### PR TITLE
Restore twine to ci runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,7 @@ jobs:
             version=$(cat .bumpversion.cfg | awk '/current_version / {print $3}')
             python setup.py register -r pypi
             python setup.py sdist
+            pip install twine
             twine upload --repository pypi dist/flake8-logging-format-${version}.tar.gz
 
 workflows:


### PR DESCRIPTION
Fix deployment issues reported in https://github.com/globality-corp/flake8-logging-format/issues/42