### PR TITLE
Add license parameter to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     author="Globality Engineering",
     author_email="engineering@globality.com",
     url="https://github.com/globality-corp/flake8-logging-format",
+    license="Apache License 2.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),


### PR DESCRIPTION
There is currently no license field in setup.py, which prevents various software (such as https://github.com/raimon49/pip-licenses) to get correct license from this package.

By merging this PR, current package will receive new metadata field `license` with `Apache License 2.0` value. This value will be shown on PyPi and in PKG-INFO files after package installation.