### PR TITLE
bumpversion to 0.9.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.1
+current_version = 0.9.0
 commit = False
 tag = False
 

--- a/logging_format/api.py
+++ b/logging_format/api.py
@@ -6,7 +6,7 @@ from logging_format.visitor import LoggingVisitor
 from logging_format.whitelist import Whitelist
 
 
-__version__ = "0.8.1"
+__version__ = "0.9.0"
 
 
 class LoggingFormatValidator(object):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "flake8-logging-format"
-version = "0.8.1"
+version = "0.9.0"
 long_description = open("README.md").read()
 
 setup(


### PR DESCRIPTION
`0.9.0` includes - 
- 22879e0b921d4430debdfb642a8a398835375062
- 5147095d6f41acdf660943b65de11443e575eaea