### PR TITLE
Compatibility with Python 3.12+

### DIFF
--- a/logging_format/whitelist.py
+++ b/logging_format/whitelist.py
@@ -2,7 +2,14 @@
 A logging extra keyword argument whitelist.
 
 """
-from pkg_resources import iter_entry_points
+from sys import version_info
+
+
+if version_info[:2] >= (3, 10):
+    # pylint: disable=no-name-in-module
+    from importlib.metadata import entry_points
+else:
+    from pkg_resources import iter_entry_points as entry_points
 
 
 class Whitelist:
@@ -15,7 +22,7 @@ class Whitelist:
     def __init__(self, group="logging.extra.whitelist"):
         self.legal_keys = {
             legal_key
-            for entry_point in iter_entry_points(group)
+            for entry_point in entry_points(group=group)
             for legal_key in entry_point.load()()
         }
 


### PR DESCRIPTION
The older `pkg_resources` package was deprecated for some time and finally removed in Python 3.12. The newer `importlib.metadata` package, built on top of the new `importlib` infrastructure in Python 3, performs better and is recommended for future use.

All tests passed against 3.9, 3.10, 3.11 and 3.12.